### PR TITLE
Reset reporter for gauges in tally

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,14 +19,14 @@ package main
 import (
 	"sync"
 
-	"github.com/tigrisdata/fly-exporter/reporter"
+	"github.com/tigrisdata/fly-exporter/provider"
 )
 
 func main() {
 	var wg sync.WaitGroup
 
 	// Create reporter to serve up prometheus metrics
-	m := reporter.NewReporter()
+	m := provider.NewMetricProvider()
 	defer m.Close()
 	go m.ServeHttp()
 	wg.Add(1)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/tigrisdata/fly-exporter/reporter"
+)
+
+type MetricProvider struct {
+	interval time.Duration
+	reporter *reporter.Reporter
+}
+
+func NewMetricProvider() MetricProvider {
+	mp := MetricProvider{
+		interval: 10 * time.Second,
+		reporter: reporter.NewReporter(),
+	}
+	return mp
+}
+
+func (mp *MetricProvider) Collect() {
+	ticker := time.NewTicker(mp.interval)
+
+	if err := mp.reporter.CollectOnce(); err != nil {
+		slog.Error("failed to collect metrics", "error", err)
+	}
+
+	for range ticker.C {
+		reporter := reporter.NewReporter()
+		if err := reporter.CollectOnce(); err != nil {
+			slog.Error("failed to collect metric data:", "error", err)
+		}
+		time.Sleep(1 * time.Second)
+		oldReporter := mp.reporter
+		mp.reporter = reporter
+		oldReporter.Close()
+	}
+	defer ticker.Stop()
+}
+
+func (mp *MetricProvider) ServeHttp() {
+	mp.reporter.ServeHttp()
+}
+
+func (mp *MetricProvider) Close() {
+	mp.reporter.Close()
+}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -35,7 +35,6 @@ import (
 type Reporter struct {
 	closer   io.Closer
 	groups   []Collectable
-	interval time.Duration
 	reporter prometheus.Reporter
 	scoped
 }
@@ -60,21 +59,27 @@ func NewReporter() *Reporter {
 	reg := pclient.NewRegistry()
 
 	r := Reporter{
-		interval: 10 * time.Second,
-		reporter: promreporter.NewReporter(promreporter.Options{Registerer: reg}),
+		reporter: promreporter.NewReporter(
+			promreporter.Options{Registerer: reg},
+		),
 	}
 
-	// Initialize base scopes
-	r.scopes = make(map[string]tally.Scope)
-	r.scopes["root"], r.closer = tally.NewRootScope(tally.ScopeOptions{
+	// Create root scope
+	scope, closer := tally.NewRootScope(tally.ScopeOptions{
 		Tags:                   GetBaseTags(),
 		CachedReporter:         r.reporter,
 		Separator:              promreporter.DefaultSeparator,
 		OmitCardinalityMetrics: true,
 	}, 1*time.Second)
-	defer r.closer.Close()
+	defer closer.Close()
 
+	// Add root scope to reporter
+	r.scopes["root"] = scope
+
+	// Add prometheus prefix for root scope
 	r.AddScope(r.scopes["root"], "fly", "fly")
+
+	// Add prometheus prefix once for machine scope, collected below
 	r.AddScope(r.scopes["fly"], "machine", "machine")
 
 	// Collect metric groups
@@ -110,7 +115,7 @@ func (r *Reporter) getReport() (*models.Report, error) {
 	return &report, nil
 }
 
-func (r *Reporter) collectOnce() error {
+func (r *Reporter) CollectOnce() error {
 	report, err := r.getReport()
 	if err != nil {
 		return err
@@ -129,16 +134,6 @@ func (r *Reporter) collectOnce() error {
 
 func (r *Reporter) Close() {
 	slog.Error("failed to close server:", "error", r.closer.Close())
-}
-
-func (r *Reporter) Collect() {
-	ticker := time.NewTicker(r.interval)
-	for range ticker.C {
-		if err := r.collectOnce(); err != nil {
-			slog.Error("failed to collect metric data:", "error", err)
-		}
-	}
-	defer ticker.Stop()
 }
 
 func (r *Reporter) ServeHttp() {

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -29,6 +29,7 @@ import (
 	pclient "github.com/m3db/prometheus_client_golang/prometheus"
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/prometheus"
+	promreporter "github.com/uber-go/tally/prometheus"
 )
 
 type Reporter struct {
@@ -60,7 +61,7 @@ func NewReporter() *Reporter {
 
 	r := Reporter{
 		interval: 10 * time.Second,
-		reporter: prometheus.NewReporter(prometheus.Options{Registerer: reg}),
+		reporter: promreporter.NewReporter(promreporter.Options{Registerer: reg}),
 	}
 
 	// Initialize base scopes
@@ -68,9 +69,11 @@ func NewReporter() *Reporter {
 	r.scopes["root"], r.closer = tally.NewRootScope(tally.ScopeOptions{
 		Tags:                   GetBaseTags(),
 		CachedReporter:         r.reporter,
-		Separator:              prometheus.DefaultSeparator,
+		Separator:              promreporter.DefaultSeparator,
 		OmitCardinalityMetrics: true,
 	}, 1*time.Second)
+	defer r.closer.Close()
+
 	r.AddScope(r.scopes["root"], "fly", "fly")
 	r.AddScope(r.scopes["fly"], "machine", "machine")
 


### PR DESCRIPTION
Reset reporter for gauges in tally. 

Fixes an issue where gauge values get "stuck" in tally and behave like counters: 

<img width="1728" alt="Screenshot 2024-09-24 at 4 36 54 PM" src="https://github.com/user-attachments/assets/2f0263d8-ce0c-4652-8b29-fdf29f22728f">


The fix is achieved by creating a new reporter each time. This was missed in the previous attempt to fix but was introduced in https://github.com/tigrisdata/fdb-exporter/pull/39.

PR also contains a small fix for resource leak.